### PR TITLE
Decimal format: support any decimal delimiter

### DIFF
--- a/java/src/com/yahoo/platform/yuitest/coverage/results/DirectoryCoverageReport.java
+++ b/java/src/com/yahoo/platform/yuitest/coverage/results/DirectoryCoverageReport.java
@@ -75,8 +75,8 @@ public class DirectoryCoverageReport {
      * @throws org.json.JSONException
      */
     public double getCalledLinePercentage() throws JSONException {
-        DecimalFormat twoDForm = new DecimalFormat("#.##");
-	return Double.valueOf(twoDForm.format(((double) getCalledLineCount() / (double) getCoveredLineCount()) * 100));
+        double d = ((double) getCalledLineCount() / (double) getCoveredLineCount()) * 10000;
+        return  Math.floor(d)/100.0;
     }
 
     /**
@@ -127,8 +127,8 @@ public class DirectoryCoverageReport {
      * @throws org.json.JSONException
      */
     public double getCalledFunctionPercentage() throws JSONException {
-        DecimalFormat twoDForm = new DecimalFormat("#.##");
-	return Double.valueOf(twoDForm.format(((double) getCalledFunctionCount() / (double) getCoveredFunctionCount()) * 100));
+        double d = ((double) getCalledFunctionCount() / (double) getCoveredFunctionCount()) * 10000;
+		  return  Math.floor(d)/100.0;
     }
 
     /**

--- a/java/src/com/yahoo/platform/yuitest/coverage/results/FileCoverageReport.java
+++ b/java/src/com/yahoo/platform/yuitest/coverage/results/FileCoverageReport.java
@@ -121,8 +121,8 @@ public class FileCoverageReport {
      * @throws org.json.JSONException
      */
     public double getCalledLinePercentage() throws JSONException {
-        DecimalFormat twoDForm = new DecimalFormat("#.##");
-	return Double.valueOf(twoDForm.format(((double) getCalledLineCount() / (double) getCoveredLineCount()) * 100));
+        double d = ((double) getCalledLineCount() / (double) getCoveredLineCount()) * 10000;
+        return  Math.floor(d)/100.0;
     }    
 
     /**
@@ -166,8 +166,8 @@ public class FileCoverageReport {
      * @throws org.json.JSONException
      */
     public double getCalledFunctionPercentage() throws JSONException {
-        DecimalFormat twoDForm = new DecimalFormat("#.##");
-	return Double.valueOf(twoDForm.format(((double) getCalledFunctionCount() / (double) getCoveredFunctionCount()) * 100));
+        double d = ((double) getCalledFunctionCount() / (double) getCoveredFunctionCount()) * 10000;
+        return  Math.floor(d)/100.0;
     }
 
     /**

--- a/java/src/com/yahoo/platform/yuitest/coverage/results/SummaryCoverageReport.java
+++ b/java/src/com/yahoo/platform/yuitest/coverage/results/SummaryCoverageReport.java
@@ -192,8 +192,8 @@ public class SummaryCoverageReport {
      * @throws org.json.JSONException
      */
     public double getCalledLinePercentage() throws JSONException {
-        DecimalFormat twoDForm = new DecimalFormat("#.##");
-	return Double.valueOf(twoDForm.format(((double) getCalledLineCount() / (double) getCoveredLineCount()) * 100));
+        double d = ((double) getCalledLineCount() / (double) getCoveredLineCount()) * 10000;
+        return  Math.floor(d)/100.0;
     }
 
     /**
@@ -244,8 +244,8 @@ public class SummaryCoverageReport {
      * @throws org.json.JSONException
      */
     public double getCalledFunctionPercentage() throws JSONException {
-        DecimalFormat twoDForm = new DecimalFormat("#.##");
-	return Double.valueOf(twoDForm.format(((double) getCalledFunctionCount() / (double) getCoveredFunctionCount()) * 100));
+        double d = ((double) getCalledFunctionCount() / (double) getCoveredFunctionCount()) * 10000;
+        return  Math.floor(d)/100.0;
     }
 
     /**


### PR DESCRIPTION
Hi,

The french local uses commas instead of dots for decimal numbers.

The Coverage report fails badly :

Can't get property calledLinePercentageName using method get/isCalledLinePercentageName from com.yahoo.platform.yuitest.coverage.results.SummaryCoverageReport instance
java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.antlr.stringtemplate.language.ASTExpr.invokeMethod(ASTExpr.java:564)
    at org.antlr.stringtemplate.language.ASTExpr.rawGetObjectProperty(ASTExpr.java:515)
    at org.antlr.stringtemplate.language.ASTExpr.getObjectProperty(ASTExpr.java:417)
    at org.antlr.stringtemplate.language.ActionEvaluator.attribute(ActionEvaluator.java:351)
    at org.antlr.stringtemplate.language.ActionEvaluator.expr(ActionEvaluator.java:136)
    at org.antlr.stringtemplate.language.ActionEvaluator.action(ActionEvaluator.java:84)
    at org.antlr.stringtemplate.language.ASTExpr.write(ASTExpr.java:149)
    at org.antlr.stringtemplate.StringTemplate.write(StringTemplate.java:705)
    at org.antlr.stringtemplate.StringTemplate.toString(StringTemplate.java:1670)
    at org.antlr.stringtemplate.StringTemplate.toString(StringTemplate.java:1661)
    at com.yahoo.platform.yuitest.writers.StringTemplateWriter.write(StringTemplateWriter.java:109)
    at com.yahoo.platform.yuitest.coverage.report.LCOVReportGenerator.generateIndexPage(LCOVReportGenerator.java:164)
    at com.yahoo.platform.yuitest.coverage.report.LCOVReportGenerator.generate(LCOVReportGenerator.java:76)
    at com.yahoo.platform.yuitest.selenium.SessionResultFileGenerator.generateCoverageFiles(SessionResultFileGenerator.java:135)
    at com.yahoo.platform.yuitest.selenium.SessionResultFileGenerator.generateAll(SessionResultFileGenerator.java:62)
    at com.yahoo.platform.yuitest.selenium.YUITestSeleniumDriver.main(YUITestSeleniumDriver.java:195)
Caused by: java.lang.NumberFormatException: For input string: "37,5"
    at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1224)
    at java.lang.Double.valueOf(Double.java:475)
    at com.yahoo.platform.yuitest.coverage.results.SummaryCoverageReport.getCalledLinePercentage(SummaryCoverageReport.java:196)
    at com.yahoo.platform.yuitest.coverage.results.SummaryCoverageReport.getCalledLinePercentageName(SummaryCoverageReport.java:206)
    ... 20 more

My fix is not very nice but works : https://github.com/neyric/yuitest/commit/6cce5ccd1b020eb72c9a642b8d38d1f4d5a72206
