### PR TITLE
Fix object assert has keys

### DIFF
--- a/javascript/src/asserts/ObjectAssert.js
+++ b/javascript/src/asserts/ObjectAssert.js
@@ -53,7 +53,7 @@ YUITest.ObjectAssert = {
      * @deprecated Use ownsOrInheritsKeys() instead
      */    
     hasKeys: function (properties, object, message) {
-        YUITest.ObjectAssert.ownsOrInheritsKeys(properties, objects, message);
+        YUITest.ObjectAssert.ownsOrInheritsKeys(properties, object, message);
     },
     
     /**


### PR DESCRIPTION
A small typo ''objects'' instead of ''object'' renders hasKeys unusable
