### PR TITLE
Fixed links to YUI Test for 2.x/3.x pages.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,8 +17,8 @@
 				<h3>JavaScript Tools</h3>
 				<ul>
 					<li><a href="standalone.html">Standalone Library</a> - use this if you want all of the YUI Test JavaScript functionality without loading YUI 2.x or YUI 3.x onto your page.</li>
-					<li><a href="/yui/2/test/">YUI Test for YUI 2.x</a> - use this if you already have tests written with the original version of YUI Test.</li>
-					<li><a href="/yui/3/test/">YUI Test for YUI 3.x</a> - use this if you already have tests written with the YUI 3.x version of YUI Test or you'd like to use YUI 3.x's dynamic loading capability to include YUI Test.</li>
+					<li><a href="http://developer.yahoo.com/yui/yuitest/">YUI Test for YUI 2.x</a> - use this if you already have tests written with the original version of YUI Test.</li>
+					<li><a href="http://developer.yahoo.com/yui/3/test/">YUI Test for YUI 3.x</a> - use this if you already have tests written with the YUI 3.x version of YUI Test or you'd like to use YUI 3.x's dynamic loading capability to include YUI Test.</li>
 				</ul>
 		
 				<h3>Continous Integration Tools</h3>


### PR DESCRIPTION
Changed to absolute full path on two links. These links is describing with remain relative path.
