### PR TITLE
fix CLI so it won't clobber absolute paths

### DIFF
--- a/javascript/src/nodejs/cli.js
+++ b/javascript/src/nodejs/cli.js
@@ -108,9 +108,9 @@ if (options.help){
     process.exit(0);
 }
 
-//get the full path names
+//Convert any relative paths to absolute paths
 files = files.map(function(filename){
-    return path.join(process.cwd(), filename);
+    return filename.charAt(0) === "/" ? filename : path.join(process.cwd(), filename);
 });
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
If you type:

yuitest /path/to/test

…this is being corrupted because we prefix each of the files array members with the cwd.

This patch makes that smarter by avoiding that prefixing if the path is already absolute.
