### PR TITLE
Small bugfixes (typo and wrong namespace) in ObjectAssert and ArrayAssert

### DIFF
--- a/javascript/src/asserts/ArrayAssert.js
+++ b/javascript/src/asserts/ArrayAssert.js
@@ -241,7 +241,7 @@ YUITest.ArrayAssert = {
         //begin checking values
         for (var i=0; i < expected.length; i++){
             if (expected[i] != actual[i]){
-                throw new YUITest.Assert.ComparisonFailure(YUITest.Assert._formatMessage(message, "Values in position " + i + " are not equal."), expected[i], actual[i]);
+                throw new YUITest.ComparisonFailure(YUITest.Assert._formatMessage(message, "Values in position " + i + " are not equal."), expected[i], actual[i]);
             }
         }
     },
@@ -278,7 +278,7 @@ YUITest.ArrayAssert = {
         //begin checking values
         for (var i=0; i < expected.length; i++){
             if (!comparator(expected[i], actual[i])){
-                throw new YUITest.Assert.ComparisonFailure(YUITest.Assert._formatMessage(message, "Values in position " + i + " are not equivalent."), expected[i], actual[i]);
+                throw new YUITest.ComparisonFailure(YUITest.Assert._formatMessage(message, "Values in position " + i + " are not equivalent."), expected[i], actual[i]);
             }
         }
     },
@@ -335,7 +335,7 @@ YUITest.ArrayAssert = {
         //begin checking values
         for (var i=0; i < expected.length; i++){
             if (expected[i] !== actual[i]){
-                throw new YUITest.Assert.ComparisonFailure(YUITest.Assert._formatMessage(message, "Values in position " + i + " are not the same."), expected[i], actual[i]);
+                throw new YUITest.ComparisonFailure(YUITest.Assert._formatMessage(message, "Values in position " + i + " are not the same."), expected[i], actual[i]);
             }
         }
     },

--- a/javascript/src/asserts/ObjectAssert.js
+++ b/javascript/src/asserts/ObjectAssert.js
@@ -53,7 +53,7 @@ YUITest.ObjectAssert = {
      * @deprecated Use ownsOrInheritsKeys() instead
      */    
     hasKeys: function (properties, object, message) {
-        YUITest.ObjectAssert.ownsOrInheritsKeys(properties, objects, message);
+        YUITest.ObjectAssert.ownsOrInheritsKeys(properties, object, message);
     },
     
     /**


### PR DESCRIPTION
This fixes a few problems in YUITest
- Fix wrong namespace to ComparisionFailure
- Fix typo in ObjectAssert.hasKeys

The ObjectAssert.hasKeys was already submitted as pull request in January but is now rebased to current master.
