### PR TITLE
Added a config for backward compat

### DIFF
--- a/javascript/src/cli/CLI-node.js
+++ b/javascript/src/cli/CLI-node.js
@@ -44,7 +44,7 @@ YUITest.CLI = {
     
         //Workaround for https://github.com/joyent/node/issues/1669
         var flushed = process.stdout.flush && process.stdout.flush();
-        if (!flushed) {
+        if (!flushed && (parseFloat(process.versions.node) < 0.5)) {
             process.once("drain", function () {
                 process.exit(code || 0);
             });

--- a/javascript/src/core/TestRunner.js
+++ b/javascript/src/core/TestRunner.js
@@ -217,11 +217,12 @@
             
             /**
             * If true, YUITest will not fire an error for tests with no Asserts.
-            * @prop ignoreEmpty
+            * @prop _ignoreEmpty
+            * @private
             * @type Boolean
             * @static
             */
-            ignoreEmpty: false,
+            _ignoreEmpty: false,
 
             //restore prototype
             constructor: YUITest.TestRunner,
@@ -605,7 +606,7 @@
                     segment.call(testCase, this._context);                    
                 
                     //if the test hasn't already failed and doesn't have any asserts...
-                    if(YUITest.Assert._getCount() == 0 && !this.ignoreEmpty){
+                    if(YUITest.Assert._getCount() == 0 && !this._ignoreEmpty){
                         throw new YUITest.AssertionError("Test has no asserts.");
                     }                                                        
                     //if it should fail, and it got here, then it's a fail because it didn't

--- a/javascript/src/core/TestRunner.js
+++ b/javascript/src/core/TestRunner.js
@@ -210,10 +210,19 @@
              * @static
              */
             this._groups = "";
+
         }
         
         TestRunner.prototype = YUITest.Util.mix(new YUITest.EventTarget(), {
-        
+            
+            /**
+            * If true, YUITest will not fire an error for tests with no Asserts.
+            * @prop ignoreEmpty
+            * @type Boolean
+            * @static
+            */
+            ignoreEmpty: false,
+
             //restore prototype
             constructor: YUITest.TestRunner,
         
@@ -596,7 +605,7 @@
                     segment.call(testCase, this._context);                    
                 
                     //if the test hasn't already failed and doesn't have any asserts...
-                    if(YUITest.Assert._getCount() == 0){
+                    if(YUITest.Assert._getCount() == 0 && !this.ignoreEmpty){
                         throw new YUITest.AssertionError("Test has no asserts.");
                     }                                                        
                     //if it should fail, and it got here, then it's a fail because it didn't


### PR DESCRIPTION
This is for @nzakas.

I added a config to YUITest.TestRunner to allow it to not throw on tests with no Assertions.

There are several test suites inside YUI that do not use Asserts since they use the "_should" assertions to tell if something throws or errors.

This just removes that extra assert when the config option is set.
