### PR TITLE
Fixed NullPointerException when coverage report json data is empty

### DIFF
--- a/java/src/com/yahoo/platform/yuitest/coverage/results/SummaryCoverageReport.java
+++ b/java/src/com/yahoo/platform/yuitest/coverage/results/SummaryCoverageReport.java
@@ -124,7 +124,7 @@ public class SummaryCoverageReport {
      * @return The filenames tracked in the report.
      */
     public String[] getFilenames(){
-        String[] filenames = JSONObject.getNames(data);
+        String[] filenames = data.length() > 0 ? JSONObject.getNames(data) : new String[]{};
         Arrays.sort(filenames);
         return filenames;
     }


### PR DESCRIPTION
When input json data is empty there is a NullPointerException.

java.lang.NullPointerException
        at java.util.Arrays.sort(Arrays.java:1078)
        at com.yahoo.platform.yuitest.coverage.results.SummaryCoverageReport.getFilenames(SummaryCoverageReport.java:116)
        at com.yahoo.platform.yuitest.coverage.results.SummaryCoverageReport.generateFileReports(SummaryCoverageReport.java:96)
        at com.yahoo.platform.yuitest.coverage.results.SummaryCoverageReport.<init>(SummaryCoverageReport.java:80)
        at com.yahoo.platform.yuitest.coverage.report.YUITestCoverageReport.main(YUITestCoverageReport.java:81)
