### PR TITLE
UnexpectedError thrown string handling

### DIFF
--- a/javascript/src/errors/UnexpectedError.js
+++ b/javascript/src/errors/UnexpectedError.js
@@ -13,7 +13,7 @@
 YUITest.UnexpectedError = function (cause){
 
     //call superclass
-    YUITest.AssertionError.call(this, "Unexpected error: " + cause.message);
+    YUITest.AssertionError.call(this, "Unexpected error: " + (cause.message || cause) );
     
     /**
      * The unexpected error that occurred.


### PR DESCRIPTION
Hello,

I've modified the UnexpectedError construtor to handle thrown strings, so it doesn't lose the string's message.
