### PR TITLE
cp yuitest-coverage-report.jar

### DIFF
--- a/nodejs-coverage/Makefile
+++ b/nodejs-coverage/Makefile
@@ -1,3 +1,4 @@
 all:
 	@echo "Copying Jar file"
 	cp ../java/build/yuitest-coverage.jar ./jar
+	cp ../java/build/yuitest-coverage-report.jar ./jar


### PR DESCRIPTION
mojito uses yuitest-coverage-report.jar and yuitest-coverage.jar
(see yahoo/mojito/tree/develop/lib/tests/harness/lib/yuitest/java/build)
for it's `mojito test -c` command at the moment. We'd like to use
the npm package (yahoo/mojito/issues/434) instead, but need 
yuitest-coverage-report.jar too...

At some point we'll migrate to yahoo/istanbul, but for now..
