### PR TITLE
Implement Assert.isNumeric()

### DIFF
--- a/javascript/src/asserts/Assert.js
+++ b/javascript/src/asserts/Assert.js
@@ -369,8 +369,49 @@ YUITest.Assert = {
         if (typeof actual != "number"){
             throw new YUITest.UnexpectedValue(YUITest.Assert._formatMessage(message, "Value should be a number."), actual);
         }    
-    },    
-    
+    },
+
+    /**
+     * Asserts that a value is a finite number or a string representing a finite number.
+     *
+     * If you expect a number you should use `Assert.isNumber` instead. Please note that
+     * this function will reject "numbers" such as `NaN` and `Infinity`.
+     *
+     * @example
+     *     Assert.isNumeric(NaN);    // fail
+     *     Assert.isNumeric(10);     // pass
+     *     Assert.isNumeric('-10');  // pass
+     *     Assert.isNumeric('10.1'); // pass
+     *     Assert.isNumeric('10px'); // fail
+     *
+     * @method isNumeric
+     * @param {String|Number} actual The value to test.
+     * @param {String} [message] message The message to display if the assertion fails.
+     * @static
+     */
+    isNumeric: function (actual, message) {
+
+        YUITest.Assert._increment();
+
+        if (typeof actual === 'number' && isFinite(actual)){
+            return;
+        }
+
+        if (typeof actual !== 'string'){
+            message = YUITest.Assert._formatMessage(message, "Value isn't a string");
+            throw new YUITest.UnexpectedValue(message, actual);
+        }
+
+        // loose comparison required in order to avoid dodgy type casting:
+        // parseFloat('13px') ~> 13; we don't want that as '13px' == 13 wouldn't have been true.
+        /*jshint eqeqeq: false*/
+        if (actual != parseFloat(actual, 10)){
+            message = YUITest.Assert._formatMessage(message, "Value isn't numeric");
+            throw new YUITest.ComparisonFailure(message, actual);
+        }
+        /*jshint eqeqeq: true*/
+    },
+
     /**
      * Asserts that a value is an object.
      * @param {Object} actual The value to test.

--- a/javascript/tests/asserts/AssertTests.js
+++ b/javascript/tests/asserts/AssertTests.js
@@ -979,12 +979,73 @@
             });
         }          
     }));        
-        
+
+    suite.add(new YUITest.TestCase({
+
+        name: "isNumeric() Assert Tests",
+        groups: ["asserts", "common"],
+
+        _should: {
+            fail: {
+                "isNumeric() should fail for NaN": true,
+                "isNumeric() should fail for Infinity": true,
+                "isNumeric() should fail for -Infinity": true,
+                "isNumeric() should fail for non numbers": true,
+                "isNumeric() should fail for dodgy number-ish: '13px'": true,
+                "isNumeric() should fail for dodgy number-ish: '10,10'": true,
+                "isNumeric() should fail for regular strings": true
+            }
+        },
+
+        "isNumeric() should pass for numbers": function () {
+            Assert.isNumeric(10     , "expected 10 to be numeric");
+            Assert.isNumeric(-10    , "expected -10 to be numeric");
+            Assert.isNumeric(10.123 , "expected 10.123 to be numeric");
+            Assert.isNumeric(0.123  , "expected 0.123 to be numeric");
+            Assert.isNumeric(-0.123 , "expected -0.123 to be numeric");
+        },
+
+        "isNumeric() should pass for strings representing numbers": function () {
+            Assert.isNumeric('10'    , "expected '10' to be numeric");
+            Assert.isNumeric('-10'   , "expected '-10' to be numeric");
+            Assert.isNumeric('10.123', "expected '10.123' to be numeric");
+            Assert.isNumeric('0.123' , "expected '0.123' to be numeric");
+            Assert.isNumeric('-0.123', "expected '-0.123' to be numeric");
+        },
+
+        "isNumeric() should fail for NaN": function () {
+            Assert.isNumeric(NaN);
+        },
+
+        "isNumeric() should fail for Infinity": function () {
+            Assert.isNumeric(Infinity);
+        },
+
+        "isNumeric() should fail for -Infinity": function () {
+            Assert.isNumeric(-Infinity);
+        },
+
+        "isNumeric() should fail for non numbers": function () {
+            Assert.isNumeric({});
+        },
+
+        "isNumeric() should fail for dodgy number-ish: '13px'": function () {
+            Assert.isNumeric('13px');
+        },
+
+        "isNumeric() should fail for dodgy number-ish: '10,10'": function () {
+            Assert.isNumeric('10,10');
+        },
+
+        "isNumeric() should fail for regular strings": function () {
+            Assert.isNumeric('hello');
+        }
+    }));
 
     //-------------------------------------------------------------------------
     // Test Case for isString() assertions
     //-------------------------------------------------------------------------
-    
+
     suite.add(new YUITest.TestCase({
     
         name: "isString() Assert Tests",


### PR DESCRIPTION
Hey guys,

On several occasions I've been placed in situations where values that I was testing could be either numbers or strings representing numbers. I know I could use `areEqual()` but this is intended for when you don't know the value in advance.

The reason why I'm rejecting NaN and the like is because `parseFloat('Infinity')` wouldn't return a number (well yeah but...). So I'd rather have the assertion works similarly for both numbers and strings.

And also I don't like NaN...

Hope you like it.

Cheers,
